### PR TITLE
画面やUXを改善

### DIFF
--- a/frontend/src/components/pages/tenants/TenantEditPage.tsx
+++ b/frontend/src/components/pages/tenants/TenantEditPage.tsx
@@ -6,11 +6,17 @@ import BackButton from "../../ui/buttons/BackButton";
 import type { TenantDetail } from "../../../models/tenants/TenantDetail";
 import type { Role } from "../../../models/roles/Role";
 import { apiClient } from "../../../api/clients/ApiClient";
+import { useAppDispatch, useAppSelector } from "../../../app/hook";
+import { getCurrentUser } from "../../../features/profile/profileSlice";
 
 /** テナントの編集ページ */
 const TenantEditPage = () => {
   const { tenantId } = useParams();
   const navigate = useNavigate();
+
+  const currentTenant = useAppSelector((root) => root.profile.userInfo?.tenant);
+  const dispatch = useAppDispatch();
+
   const [tenant, setTenant] = useState<TenantDetail | null>(null);
   const [roles, setRoles] = useState<Role[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -58,6 +64,10 @@ const TenantEditPage = () => {
       await apiClient.tenants.updateTenant(tenantId, {
         name: formData.name,
       });
+
+      if (tenantId === currentTenant?.id) {
+        await dispatch(getCurrentUser());
+      }
 
       alert("テナント情報を更新しました。");
       navigate("/tenants");

--- a/frontend/src/components/pages/tenants/TenantEditPage.tsx
+++ b/frontend/src/components/pages/tenants/TenantEditPage.tsx
@@ -69,7 +69,6 @@ const TenantEditPage = () => {
         await dispatch(getCurrentUser());
       }
 
-      alert("テナント情報を更新しました。");
       navigate("/tenants");
     } catch (e) {
       const error = await apiClient.parseHttpError(e);

--- a/frontend/src/components/pages/tenants/TenantNewPage.tsx
+++ b/frontend/src/components/pages/tenants/TenantNewPage.tsx
@@ -48,7 +48,6 @@ const TenantNewPage = () => {
         initUser: formData.initUser!,
       });
 
-      alert("テナントを作成しました。");
       navigate("/tenants");
     } catch (e) {
       const error = await apiClient.parseHttpError(e);

--- a/frontend/src/components/pages/users/UserEditPage.tsx
+++ b/frontend/src/components/pages/users/UserEditPage.tsx
@@ -87,7 +87,6 @@ const UserEditPage = () => {
         await dispatch(getCurrentUser());
       }
 
-      alert("ユーザー情報を更新しました。");
       navigate("/users");
     } catch (e) {
       const error = await apiClient.parseHttpError(e);

--- a/frontend/src/components/pages/users/UserEditPage.tsx
+++ b/frontend/src/components/pages/users/UserEditPage.tsx
@@ -6,11 +6,17 @@ import BackButton from "../../ui/buttons/BackButton";
 import type { UserDetail } from "../../../models/users/UserDetail";
 import type { Role } from "../../../models/roles/Role";
 import { apiClient } from "../../../api/clients/ApiClient";
+import { useAppDispatch, useAppSelector } from "../../../app/hook";
+import { getCurrentUser } from "../../../features/profile/profileSlice";
 
 /** ユーザー編集ページ */
 const UserEditPage = () => {
   const { userId } = useParams();
   const navigate = useNavigate();
+
+  const currentUser = useAppSelector((root) => root.profile.userInfo?.user);
+  const dispatch = useAppDispatch();
+
   const [editUer, setEditUser] = useState<UserDetail | null>(null);
   const [roles, setRoles] = useState<Role[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -76,6 +82,10 @@ const UserEditPage = () => {
       }
 
       await apiClient.users.updateUser(userId, updateRequest);
+
+      if (userId === currentUser?.id) {
+        await dispatch(getCurrentUser());
+      }
 
       alert("ユーザー情報を更新しました。");
       navigate("/users");

--- a/frontend/src/components/pages/users/UserNewPage.tsx
+++ b/frontend/src/components/pages/users/UserNewPage.tsx
@@ -48,7 +48,6 @@ const UserNewPage = () => {
         roleId: formData.roleId,
       });
 
-      alert("ユーザーを作成しました。");
       navigate("/users");
     } catch (e) {
       const error = await apiClient.parseHttpError(e);

--- a/frontend/src/components/templates/MainTemplate.tsx
+++ b/frontend/src/components/templates/MainTemplate.tsx
@@ -5,6 +5,7 @@ import { useAppSelector } from "../../app/hook";
 import logo from "../../assets/logo.svg";
 import Sidebar from "../ui/sidebar/Sidebar";
 import { NavLink } from "react-router-dom";
+import { BuildingOfficeIcon, UserIcon } from "@heroicons/react/24/solid";
 
 /** メインテンプレートのProps */
 interface MainTemplateProps {
@@ -29,10 +30,20 @@ const MainTemplate: React.FC<MainTemplateProps> = ({ children }) => {
 
         <div className="flex ml-16">
           {/* テナント名 */}
-          <span className="ml-2 mr-4">テナント: {userInfo?.tenant.name}</span>
+          <div className="flex items-center ml-2 mr-4">
+            <span className="shrink-0">
+              <BuildingOfficeIcon className="w-5 h-5" />
+            </span>
+            <span className="ml-1">{userInfo?.tenant.name}</span>
+          </div>
 
           {/* 氏名 */}
-          <span>ユーザー: {userInfo?.user.username}</span>
+          <div className="flex items-center ml-2 mr-4">
+            <span className="shrink-0">
+              <UserIcon className="w-5 h-5" />
+            </span>
+            <span className="ml-1">{userInfo?.user.username}</span>
+          </div>
         </div>
 
         <a


### PR DESCRIPTION
- 自身の情報表示エリアにアイコンを表示
- 自身のユーザー情報やテナント情報を更新したときに、プロフィール情報を再取得
- CRUD成功時はalertでメッセージを表示しないように変更